### PR TITLE
add cache

### DIFF
--- a/app/Cache.php
+++ b/app/Cache.php
@@ -1,0 +1,45 @@
+<?php
+namespace App;
+
+class Cache {
+	
+	const CACHE_LIFETIME = 60 * 5;
+	
+	protected $path;
+	
+	public function __construct(string $path = null) {
+		$this->path = $path ?? __DIR__ . '/../cache';
+	}
+	
+	public function set(string $file, array $data) {
+		$cache = [
+			'ts' => time(),
+			'data' => $data,
+		];
+		
+		file_put_contents($this->filePath($file), json_encode($cache));
+	}
+	
+	public function get(string $file) {
+		$path = $this->filePath($file);
+		if(file_exists($path)) {
+			$contents = file_get_contents($path);
+			$data = json_decode($contents, true);
+			if(!is_array($data) || !array_key_exists('ts', $data)) {
+				return false;
+			}
+			
+			return $this->compare($data['ts']) ? $data['data'] : false;
+		}
+		
+		return false;
+	}
+	
+	protected function compare(int $ts) {
+		return time() < $ts + self::CACHE_LIFETIME;
+	}
+	
+	protected function filePath(string $file) {
+		return $this->path . '/' . $file;
+	}
+}

--- a/app/DataProvider.php
+++ b/app/DataProvider.php
@@ -1,0 +1,49 @@
+<?php
+namespace App;
+
+use GuzzleHttp\Client;
+
+class DataProvider {
+	
+	protected $http;
+	protected $cache;
+	
+	public function __construct() {
+		$this->http = new Client();
+		$this->cache = new Cache();
+	}
+	
+	public function getData() {
+		$data = $this->cache->get('episodes');
+		if($data === false) {
+			$data = $this->retrieve();
+			if($data === null) {
+				return [
+					'status' => false,
+				];
+			}
+			
+			$this->cache->set('episodes', $data);
+		}
+		
+		return [
+			'status' => true,
+			'data' => $data,
+		];
+	}
+	
+	protected function retrieve() {
+		try {
+			$res = $this->http->request('GET', 'http://3ev.org/dev-test-api/');
+			$data = json_decode($res->getBody(), true);
+
+			//Sort the episodes
+			array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+		}
+		catch(\GuzzleHttp\Exception\ServerException $e) {
+			return null;
+		}
+		
+		return $data;
+	}
+}

--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "require": {
         "twig/twig": "^1.24",
         "guzzlehttp/guzzle": "^6.2"
+    },
+	"autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -6,12 +6,7 @@ $loader = new Twig_Loader_Filesystem('../templates/');
 $twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
-
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
-
+$provider = new \App\DataProvider();
+$data = $provider->getData();
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', ["episodes" => $data['data'], 'status' => $data['status']]);

--- a/templates/page.html
+++ b/templates/page.html
@@ -15,13 +15,21 @@
     </div>
 
     <div class="container">
-        {% for episode in episodes %}
-            {% if loop.index%2 == 1 %}<div class="row">{%endif %}
+		{% if status == false %}
+			<div class="row">
+				<div class="col-md-12">
+					<p class="alert alert-danger">Sorry, there was an error. Please try again by reloading the page.</p>
+				</div>
+			</div>
+		{% else %}
+			{% for episode in episodes %}
+				{% if loop.index%2 == 1 %}<div class="row">{%endif %}
 
-                {{ include('episode.html') }}
-        
-            {% if loop.index%2 == 0 %}</div>{%endif %}
-        {% endfor %}
+					{{ include('episode.html') }}
+
+				{% if loop.index%2 == 0 %}</div>{%endif %}
+			{% endfor %}
+		{% endif %}
     </div>
 
     <footer class="footer">


### PR DESCRIPTION
This PR adds a simple caching mechanism so the api results don't have to be downloaded with every request. By default results are cached for five minutes.

---

**Testing**

To make sure the caching mechanism works check the cache folder. After an initial request a new file should be created. The application should work regardless of the file being present or even valid.

---

**Deployment steps**

Merge branch `change1` into `master`
composer dump-autoload
