### PR TITLE
issue1 sort by season, episode

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,9 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+$seasons = array_column($data, 'season');
+$episodes = array_column($data, 'episode');
+array_multisort($seasons, SORT_ASC, $episodes, SORT_ASC, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION

This PR corrects sort order on Bobby's favourite episodes, so they are ordered by ascending series then ascending episode number.

---

**Testing**

In a browser verify that the episodes are ordered as specified.

---

**Deployment steps**

Merge branch `issue1` into `master`
