### PR TITLE
issue2 show user-friendly messages on Guzzle exceptions

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,0 +1,9 @@
+Issue 2 - show user-friendly messages on Guzzle exceptions
+Release notes : there are unhandled Twig exceptions, raise a separate issue
+
+Test Plan
+Ideally Mock the API to simulate error and success responses.
+Replicate issue without the patch.
+Apply patch.
+Verify view contains desired error message on Guzzle Exception
+Verify view behaviour unchanged on successful API response

--- a/public/index.php
+++ b/public/index.php
@@ -7,11 +7,19 @@ $twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
 $client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
-
+try {
+    $error = null;
+    $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+    $data = json_decode($res->getBody(), true);
+} catch (\GuzzleHttp\Exception\GuzzleException $e) {
+    $data = [];
+    $error = 'Sorry, there was an error. Please try again by reloading the page.';
+}
 //Sort the episodes
 array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
 
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', [
+    "episodes" => $data,
+    "error" => $error
+]);

--- a/templates/page.html
+++ b/templates/page.html
@@ -15,6 +15,11 @@
     </div>
 
     <div class="container">
+        {% if error %}
+        <div class="alert alert-danger" role="alert">
+            {{ error}}
+        </div>
+        {%endif %}
         {% for episode in episodes %}
             {% if loop.index%2 == 1 %}<div class="row">{%endif %}
 


### PR DESCRIPTION

This PR catches Guzzle exceptions thrown by the API endpoint, displaying instead a bootstrap styled user-friendly error message in place of the episodes list

---

**Testing**

The API seems to throw Guzzle exceptions somewhat randomly, so rather than mock the API, just keep refreshing the browser page until the API throws an exception
See Test Plan in NOTES file.

---

**Deployment steps**

Merge branch `issue2` into `master`
