### PR TITLE
issue4 show episode popover should hide previous episode popover

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,0 +1,4 @@
+Issue 4 : showing an episode popover should hide all other episode popovers
+
+Release notes
+Recompile js with gulp

--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -13,7 +13,11 @@ module.exports = function () {
         selector: '[data-toggle="popover"]',
         container: 'body',
         viewport: { selector: 'body', padding: 20 }
-    })
+    }).on("show.bs.popover", function(e){
+        // hide all other popovers
+        $("[rel=popover]").not(e.target).popover("destroy");
+        $(".popover").remove();
+    });
     
     // Initialise Bootstrap tooltips
     //http://getbootstrap.com/javascript/#tooltips

--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -10,12 +10,12 @@ module.exports = function () {
 
     // initialise all popovers
     $('body').popover({
-        selector: '[data-toggle="popover"]',
+        selector: "[data-toggle=popover]",
         container: 'body',
         viewport: { selector: 'body', padding: 20 }
     }).on("show.bs.popover", function(e){
         // hide all other popovers
-        $("[rel=popover]").not(e.target).popover("destroy");
+        $("[data-toggle=popover]").not(e.target).popover("destroy");
         $(".popover").remove();
     });
     


### PR DESCRIPTION
This PR corrects the episode image popover behaviour, so that only one popover at a time can be shown.

---

**Testing**

In a browser with episodes populated, verify that after clicking the first episode image that the popover appears. Click the second episode image and verify that its popover appears and the first's is hidden.

Note: noticed later clicking around that there is a weakness with this fix. After the test scenario above, re-clicking on the first episode image does nothing. A second click on the first image is required to activate its popover. This seems to hold for any sequence including a previously active popover. Further investigation required.
---

**Deployment steps**

Merge branch `issue4` into `master`

Compile assets: `./bin/node_modules/gulp`
