### PR TITLE
Fixed issue#1 - Shows displayed in season->episode order

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,8 +10,8 @@ $client = new GuzzleHttp\Client();
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+//Sort the episodes by season then episode by using natural
+array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
This PR changes the sort order of the displayed TV shows into season then episode number in ascending order.

---

**Testing**

View the site in a browser and confirm the order is that expected.

---

**Deployment steps**

Merge branch `issue1` into `master`. 
No gulp compiling needed for this change.
